### PR TITLE
Spin --> Region

### DIFF
--- a/R/spinner_plot.R
+++ b/R/spinner_plot.R
@@ -2,10 +2,10 @@ spinner_plot <- function(probs, ...){
    args <- list(...)
    if("values" %in% names(args))
      values <- args$values else
-     values <- 1:length(probs)
-   Spin <- factor(values)
+     values <- seq_along(probs)
+   Region <- factor(values)
    y <- probs
-   df <- data.frame(Spin, y)
+   df <- data.frame(Region, y)
    TH <- theme(
      plot.title = element_text(
        colour = "blue",
@@ -15,7 +15,7 @@ spinner_plot <- function(probs, ...){
        angle = 0
      )
    )
-   p <- ggplot(df, aes(1, y, fill=Spin)) +
+   p <- ggplot(df, aes(1, y, fill=Region)) +
    geom_bar(stat="identity") +
    coord_polar(theta = "y", direction=1) +
      xlab("") + ylab("") +

--- a/R/spinner_probs.R
+++ b/R/spinner_probs.R
@@ -1,4 +1,4 @@
 spinner_probs <- function(regions){
-  data.frame(Spin=1:length(regions),
-             Prob=regions / sum(regions))
+  data.frame(Region = seq_along(regions),
+             Prob = regions / sum(regions))
 }

--- a/man/spinner_plot.Rd
+++ b/man/spinner_plot.Rd
@@ -31,6 +31,6 @@
   spinner_plot(probs,
          values=c("A", "B", "C", "D", "E"),
          title="My Spinner")
-  # probs does not need to be noramalized
+  # probs does not need to be normalized
   spinner_plot(c(1, 2, 1, 2))
 }

--- a/man/spinner_probs.Rd
+++ b/man/spinner_probs.Rd
@@ -17,7 +17,7 @@
 }
 
 \value{
-  Data frame with variables Spin and Prob
+  Data frame with variables Region and Prob
 }
 \author{
   Jim Albert


### PR DESCRIPTION
@bayesball I'm wondering if we can change `Spin` to `Region` in the output from both `spinner_probs()` and `spinner_plot()`? I find this language to be less confusing, as `Spin` might be interpreted the spin number in a series of consecutive spins. You also use the word "region" throughout the first chapter of the course, so this will help with consistency. Feedback welcome!

[Warning: I didn't make any updates to the vignettes. Not sure if those will need to be updated.]